### PR TITLE
Speaker section #88

### DIFF
--- a/src/routes/webinars/[slug]/+page.svelte
+++ b/src/routes/webinars/[slug]/+page.svelte
@@ -85,7 +85,7 @@
       font-weight: 300;
       font-size: var(--font-size-sm);
     }
-    
+
     & a {
       width: fit-content;
       text-decoration: none;
@@ -119,8 +119,8 @@
     }
 
     .speaker-info img {
-      width: 90px;
-      height: 90px;
+      width: 70px;
+      height: 70px;
     }
 
     .speaker-info div{

--- a/src/routes/webinars/[slug]/+page.svelte
+++ b/src/routes/webinars/[slug]/+page.svelte
@@ -15,6 +15,33 @@
     {@html data.webinar.description}
   </div>
   
+  <article class='speakers'>
+    {#if data.webinar.speakers.length > 1}
+      <h2>About the speakers</h2>
+    {:else}
+      <h2>About the speaker</h2>
+    {/if}
+
+    {#each data.webinar.speakers as speaker}
+      <section class="speaker-info">
+        <img src="https://fdnd-agency.directus.app/assets/{speaker.avl_speakers_id.profile_picture}?format=avif" alt="{speaker.avl_speakers_id.fullname}" width="90px" height="90px">
+
+        <div>
+          <h3>{speaker.avl_speakers_id.fullname}</h3>
+          <p>{speaker.avl_speakers_id.entitle}</p>
+        </div>
+
+        <a href="/speakers/{speaker.avl_speakers_id.slug}">
+          <svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="30" height="30" viewBox="0 0 48 48">
+            <circle cx="24" cy="24" r="20" fill="var(--alt-text-color)" />
+            <path d="M24,4C12.972,4,4,12.972,4,24s8.972,20,20,20s20-8.972,20-20S35.028,4,24,4z M25.5,33.5c0,0.828-0.672,1.5-1.5,1.5	s-1.5-0.672-1.5-1.5v-11c0-0.828,0.672-1.5,1.5-1.5s1.5,0.672,1.5,1.5V33.5z M24,18c-1.105,0-2-0.895-2-2c0-1.105,0.895-2,2-2	s2,0.895,2,2C26,17.105,25.105,18,24,18z"></path>
+          </svg>
+          <span>See speaker profile</span>
+        </a>
+      </section>
+    {/each}
+  </article>
+
   <div class='q-a'>
     <QandA 
       comments = {data.comments} />
@@ -31,6 +58,49 @@
     margin: 0 auto;
   }
 
+  .speakers {
+    padding-block: 2rem;
+    max-width: 900px;
+    display: grid;
+    gap: 1rem;
+  }
+
+  .speaker-info {
+    display: flex;
+    align-items: center;
+    gap: var(--gap);
+
+    & img {
+      object-fit: cover;
+      border-radius: 50%;
+      width: 50px;
+      height: 50px;
+    }
+
+    & div {
+      width: 70%;
+    }
+
+    & p {
+      font-weight: 300;
+      font-size: var(--font-size-sm);
+    }
+    
+    & a {
+      width: fit-content;
+      text-decoration: none;
+      color: var(--primary-color);
+
+      & svg {
+        fill: var(--primary-color);
+      }
+
+      & span {
+        display: none;
+      }
+    }
+  }
+
   .q-a {
     width: 90vw;
     max-width: 500px;
@@ -42,4 +112,37 @@
       width: 50vw;
     }
   }
+
+  @media screen and (min-width: 900px){
+    .speaker-info {
+      gap: 1rem;
+    }
+
+    .speaker-info img {
+      width: 90px;
+      height: 90px;
+    }
+
+    .speaker-info div{
+      width: 65%;
+    }
+
+    .speaker-info a:hover {
+      text-decoration: underline;
+    }
+
+    .speaker-info a svg {
+      display: none;
+    }
+
+    .speaker-info a span {
+      display: block;
+    }
+
+    .speaker-info a span::after {
+      content: '>';
+      padding-inline-start: 10px;
+    }
+  }
+
 </style>

--- a/src/routes/webinars/[slug]/+page.svelte
+++ b/src/routes/webinars/[slug]/+page.svelte
@@ -17,9 +17,9 @@
   
   <article class='speakers'>
     {#if data.webinar.speakers.length > 1}
-      <h2>About the speakers</h2>
+      <h2>The speakers</h2>
     {:else}
-      <h2>About the speaker</h2>
+      <h2>The speaker</h2>
     {/if}
 
     {#each data.webinar.speakers as speaker}
@@ -36,7 +36,7 @@
             <circle cx="24" cy="24" r="20" fill="var(--alt-text-color)" />
             <path d="M24,4C12.972,4,4,12.972,4,24s8.972,20,20,20s20-8.972,20-20S35.028,4,24,4z M25.5,33.5c0,0.828-0.672,1.5-1.5,1.5	s-1.5-0.672-1.5-1.5v-11c0-0.828,0.672-1.5,1.5-1.5s1.5,0.672,1.5,1.5V33.5z M24,18c-1.105,0-2-0.895-2-2c0-1.105,0.895-2,2-2	s2,0.895,2,2C26,17.105,25.105,18,24,18z"></path>
           </svg>
-          <span>See speaker profile</span>
+          <span>About this speaker</span>
         </a>
       </section>
     {/each}


### PR DESCRIPTION
## What does this change?
Adds the speaker section of the webinar detailpage.

https://github.com/itsValyria/Oncollaboration/blob/98ec60216726454e1c1186ef950ad3c1a042ccbe/src/routes/webinars/%5Bslug%5D/%2Bpage.svelte#L18-L43

https://github.com/itsValyria/Oncollaboration/blob/98ec60216726454e1c1186ef950ad3c1a042ccbe/src/routes/webinars/%5Bslug%5D/%2Bpage.svelte#L61-L102

https://github.com/itsValyria/Oncollaboration/blob/98ec60216726454e1c1186ef950ad3c1a042ccbe/src/routes/webinars/%5Bslug%5D/%2Bpage.svelte#L116-L146

## How Has This Been Tested?
- [x] User test
- [x] Accessibility test
- [x] Performance test
- [x] Responsive Design test
- [x] Device test
- [x] Browser test
 
### User test
It is intuitive to klik on the button for more information about the speaker.

### Accessibility test
Lighthouse test 100.

### Performance test
Lighthouse test 100.

### Responsive Design test
It is responsive you can use it on all screen sizes.

### Device test
Tested on MacBook, Ipad, Iphone works on all of them.

### Browser test
Tested on Arc, Chrome, Safari, Firefox and works on all of them.

## Images
### Mobile
![IMG_237C1E6B463C-1](https://github.com/user-attachments/assets/dd0a559f-52f8-4ad3-afcb-a3fd43f13751)

### Desktop
<img width="917" alt="Screenshot 2025-01-09 at 3 58 53 PM" src="https://github.com/user-attachments/assets/7dadef9b-040b-44ca-a404-2385a974ef2e" />
 
## How to review
Go to a webinar page and check out the speakers. If you click on the error page you get the error page this is because we haven't made the speakers page yet.
